### PR TITLE
Adding attention mechanism with sampled softmax

### DIFF
--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -113,7 +113,8 @@ class Chatbot:
         nnArgs.add_argument('--hiddenSize', type=int, default=256, help='number of hidden units in each RNN cell')
         nnArgs.add_argument('--numLayers', type=int, default=2, help='number of rnn layers')
         nnArgs.add_argument('--embeddingSize', type=int, default=32, help='embedding size of the word representation')
-
+        nnArgs.add_argument('--softmaxSamples', type=int, default=512, help='Number of samples in the sampled softmax loss function. A value of 0 deactivates sampled softmax')
+        
         # Training options
         trainingArgs = parser.add_argument_group('Training options')
         trainingArgs.add_argument('--numEpochs', type=int, default=30, help='maximum number of epochs to run')
@@ -450,6 +451,7 @@ class Chatbot:
             self.args.hiddenSize = config['Network'].getint('hiddenSize')
             self.args.numLayers = config['Network'].getint('numLayers')
             self.args.embeddingSize = config['Network'].getint('embeddingSize')
+            self.args.softmaxSamples = config['Network'].getint('softmaxSamples')
 
             # No restoring for training params, batch size or other non model dependent parameters
 
@@ -462,6 +464,7 @@ class Chatbot:
             print('hiddenSize: {}'.format(self.args.hiddenSize))
             print('numLayers: {}'.format(self.args.numLayers))
             print('embeddingSize: {}'.format(self.args.embeddingSize))
+            print('softmaxSamples: {}'.format(self.args.softmaxSamples))
             print()
 
         # For now, not arbitrary  independent maxLength between encoder and decoder
@@ -487,6 +490,7 @@ class Chatbot:
         config['Network']['hiddenSize'] = str(self.args.hiddenSize)
         config['Network']['numLayers'] = str(self.args.numLayers)
         config['Network']['embeddingSize'] = str(self.args.embeddingSize)
+        config['Network']['softmaxSamples'] = str(self.args.softmaxSamples)
 
         # Keep track of the learning params (but without restoring them)
         config['Training (won\'t be restored)'] = {}

--- a/chatbot/model.py
+++ b/chatbot/model.py
@@ -1,4 +1,5 @@
 # Copyright 2015 Conchylicultor. All Rights Reserved.
+# Modifications copyright (C) 2016 Carlos Segura
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +52,13 @@ class Model:
         self.lossFct = None
         self.optOp = None
         self.outputs = None  # Outputs of the network, list of probability for each words
+        
+        # Parameters of sampled softmax (needed for attention mechanism and a larg vocabulry size)
+        self.output_projection = None
+        self.softmax_loss_function = None
+        self.num_samples = self.args.softmaxSamples
+        self.dtype=tf.float32
+
 
         # Construct the graphs
         self.buildNetwork()
@@ -61,6 +69,27 @@ class Model:
 
         # TODO: Create name_scopes (for better graph visualisation)
         # TODO: Use buckets (better perfs)
+
+        # Sampled softmax only makes sense if we sample less than vocabulary size.
+        if self.num_samples > 0 and self.num_samples < self.textData.getVocabularySize():
+          w = tf.get_variable("proj_w", [self.args.hiddenSize, self.textData.getVocabularySize()], dtype=self.dtype)
+          w_t = tf.transpose(w)
+          b = tf.get_variable("proj_b", [self.textData.getVocabularySize()], dtype=self.dtype)
+          self.output_projection = (w, b)
+
+          def sampled_loss(inputs, labels):
+            labels = tf.reshape(labels, [-1, 1])
+            # We need to compute the sampled_softmax_loss using 32bit floats to
+            # avoid numerical instabilities.
+            local_w_t = tf.cast(w_t, tf.float32)
+            local_b = tf.cast(b, tf.float32)
+            local_inputs = tf.cast(inputs, tf.float32)
+            return tf.cast(
+                tf.nn.sampled_softmax_loss(local_w_t, local_b, local_inputs, labels,
+                                          self.num_samples, self.textData.getVocabularySize()),
+                self.dtype)
+          self.softmax_loss_function = sampled_loss
+
 
         # Creation of the rnn cell
         with tf.variable_scope("chatbot_cell"):  # TODO: How to make this appear on the graph ?
@@ -88,19 +117,27 @@ class Model:
             self.textData.getVocabularySize(),
             self.textData.getVocabularySize(),  # Both encoder and decoder have the same number of class
             embedding_size=self.args.embeddingSize,  # Dimension of each word
-            output_projection=None,  # Eventually
+            output_projection=self.output_projection,  # Eventually
             feed_previous=bool(self.args.test)  # When we test (self.args.test), we use previous output as next input (feed_previous)
         )
 
         # For testing only
         if self.args.test:
             self.outputs = decoderOutputs
+            if self.output_projection is not None:
+                self.outputs = [ tf.matmul(output, self.output_projection[0]) + self.output_projection[1]
+                                  for output in self.outputs
+                               ]
+            
             # TODO: Attach a summary to visualize the output
 
         # For training only
         else:
             # Finally, we define the loss function
-            self.lossFct = tf.nn.seq2seq.sequence_loss(decoderOutputs, self.decoderTargets, self.decoderWeights, self.textData.getVocabularySize())
+            if self.softmax_loss_function is None:
+                self.lossFct = tf.nn.seq2seq.sequence_loss(decoderOutputs, self.decoderTargets, self.decoderWeights, self.textData.getVocabularySize())
+            else:
+                self.lossFct = tf.nn.seq2seq.sequence_loss(decoderOutputs, self.decoderTargets, self.decoderWeights, self.textData.getVocabularySize(),  softmax_loss_function = self.softmax_loss_function)
             tf.scalar_summary('loss', self.lossFct)  # Keep track of the cost
 
             # Initialize the optimizer


### PR DESCRIPTION
The attention mechanism needs a lot of memory when the vocabulary size is very large. Based on the translation model in Tensorflow repository https://github.com/tensorflow/tensorflow/blob/r0.11/tensorflow/models/rnn/translate/seq2seq_model.py I added the option to use "sampled softmax" as the loss function, that trains only with softmaxSamples random words at each step instead of using all possible words.

Setting softmaxSamples to zero disables sampled softmax.