### PR TITLE
Migration work to TF v0.12.0

### DIFF
--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -170,7 +170,7 @@ class Chatbot:
         self.sess = tf.Session()  # TODO: Replace all sess by self.sess (not necessary a good idea) ?
 
         print('Initialize variables...')
-        self.sess.run(tf.initialize_all_variables())
+        self.sess.run(tf.global_variables_initializer())
 
         # Reload the model eventually (if it exist.), on testing mode, the models are not loaded here (but in predictTestset)
         if self.args.test != Chatbot.TestMode.ALL:

--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -157,7 +157,7 @@ class Chatbot:
             self.model = Model(self.args, self.textData)
 
         # Saver/summaries
-        self.writer = tf.train.SummaryWriter(self._getSummaryName())
+        self.writer = tf.summary.FileWriter(self._getSummaryName())
         self.saver = tf.train.Saver(max_to_keep=200)  # Arbitrary limit ?
 
         # TODO: Fixed seed (WARNING: If dataset shuffling, make sure to do that after saving the
@@ -207,7 +207,7 @@ class Chatbot:
 
         self.textData.makeLighter(self.args.ratioDataset)  # Limit the number of training samples
 
-        mergedSummaries = tf.merge_all_summaries()  # Define the summary operator (Warning: Won't appear on the tensorboard graph)
+        mergedSummaries = tf.summary.merge_all()  # Define the summary operator (Warning: Won't appear on the tensorboard graph)
         if self.globStep == 0:  # Not restoring from previous run
             self.writer.add_graph(sess.graph)  # First time only
 

--- a/chatbot/model.py
+++ b/chatbot/model.py
@@ -186,7 +186,7 @@ class Model:
                 self.textData.getVocabularySize(),
                 softmax_loss_function= sampledSoftmax if outputProjection else None  # If None, use default SoftMax
             )
-            tf.scalar_summary('loss', self.lossFct)  # Keep track of the cost
+            tf.summary.scalar('loss', self.lossFct)  # Keep track of the cost
 
             # Initialize the optimizer
             opt = tf.train.AdamOptimizer(


### PR DESCRIPTION
Variables initialization method is deprecated.
So, fixed, to get it more clear.