### PR TITLE
Add support for the OpenSubtitles corups (Tiedemann, 2009)

### DIFF
--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -103,7 +103,7 @@ class Chatbot:
 
         # Dataset options
         datasetArgs = parser.add_argument_group('Dataset options')
-        datasetArgs.add_argument('--corpus', type=str, default='cornell', help='corpus on which extract the dataset. Only one corpus available right now (Cornell)')
+        datasetArgs.add_argument('--corpus', type=str, default='cornell', help='corpus on which extract the dataset. Only two corpus available right now (cornell and opensubs)')
         datasetArgs.add_argument('--datasetTag', type=str, default=None, help='add a tag to the dataset (file where to load the vocabulary and the precomputed samples, not the original corpus). Useful to manage multiple versions')  # The samples are computed from the corpus if it does not exist already. There are saved in \'data/samples/\'
         datasetArgs.add_argument('--ratioDataset', type=float, default=1.0, help='ratio of dataset used to avoid using the whole dataset')  # Not implemented, useless ?
         datasetArgs.add_argument('--maxLength', type=int, default=10, help='maximum length of the sentence (for input and output), define number of maximum step of the RNN')

--- a/chatbot/cornelldata.py
+++ b/chatbot/cornelldata.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+import os
+
 """
 Load the cornell movie dialog corpus.
 
@@ -37,8 +39,8 @@ class CornellData:
         MOVIE_LINES_FIELDS = ["lineID","characterID","movieID","character","text"]
         MOVIE_CONVERSATIONS_FIELDS = ["character1ID","character2ID","movieID","utteranceIDs"]
 
-        self.lines = self.loadLines(dirName + "movie_lines.txt", MOVIE_LINES_FIELDS)
-        self.conversations = self.loadConversations(dirName + "movie_conversations.txt", MOVIE_CONVERSATIONS_FIELDS)
+        self.lines = self.loadLines(os.path.join(dirName, "movie_lines.txt"), MOVIE_LINES_FIELDS)
+        self.conversations = self.loadConversations(os.path.join(dirName, "movie_conversations.txt"), MOVIE_CONVERSATIONS_FIELDS)
 
         # TODO: Cleaner program (merge copy-paste) !!
 

--- a/chatbot/opensubsdata.py
+++ b/chatbot/opensubsdata.py
@@ -1,0 +1,133 @@
+# Based on code from https://github.com/AlJohri/OpenSubtitles
+# by Al Johri <al.johri@gmail.com>
+
+import xml.etree.ElementTree as ET
+import datetime
+import os
+import sys
+import json
+import re
+import pprint
+
+from gzip import GzipFile
+from tqdm import tqdm
+
+"""
+Load the opensubtitles dialog corpus.
+"""
+
+class OpensubsData:
+    """
+
+    """
+
+    def __init__(self, dirName):
+        """
+        Args:
+            dirName (string): directory where to load the corpus
+        """
+
+        # Hack this to filter on subset of Opensubtitles
+        # dirName = "%s/en/Action" % dirName
+
+        print("Loading OpenSubtitles conversations in %s." % dirName)
+        self.conversations = []
+        self.tag_re = re.compile(r'(<!--.*?-->|<[^>]*>)')
+        self.conversations = self.loadConversations(dirName)
+
+    def loadConversations(self, dirName):
+        """
+        Args:
+            dirName (str): folder to load
+        Return:
+            array(question, answer): the extracted QA pairs
+        """
+        conversations = []
+        dirList = self.filesInDir(dirName)
+        for filepath in tqdm(dirList, "OpenSubtitles data files"):
+            if filepath.endswith('gz'):
+                try:
+                    doc = self.getXML(filepath)
+                    conversations.extend(self.genList(doc))
+                except ValueError:
+                    tqdm.write("Skipping file %s with errors." % filepath)
+                except:
+                    print("Unexpected error:", sys.exc_info()[0])
+                    raise
+        return conversations
+
+    def getConversations(self):
+        return self.conversations
+
+    def genList(self, tree):
+        root = tree.getroot()
+
+        timeFormat = '%H:%M:%S'
+        maxDelta = datetime.timedelta(seconds=1)
+
+        startTime = datetime.datetime.min
+        strbuf = ''
+        sentList = []
+
+        for child in root:
+            for elem in child:
+                if elem.tag == 'time':
+                    elemID = elem.attrib['id']
+                    elemVal = elem.attrib['value'][:-4]
+                    if elemID[-1] == 'S':
+                        startTime = datetime.datetime.strptime(elemVal, timeFormat)
+                    else:
+                        sentList.append((strbuf.strip(), startTime, datetime.datetime.strptime(elemVal, timeFormat)))
+                        strbuf = ''
+                else:
+                    try:
+                        strbuf = strbuf + " " + elem.text
+                    except:
+                        pass
+
+        conversations = []
+        for idx in range(0, len(sentList) - 1):
+            cur = sentList[idx]
+            nxt = sentList[idx + 1]
+            if nxt[1] - cur[2] <= maxDelta and cur and nxt:
+                tmp = {}
+                tmp["lines"] = []
+                tmp["lines"].append(self.getLine(cur[0]))
+                tmp["lines"].append(self.getLine(nxt[0]))
+                if self.filter(tmp):
+                    conversations.append(tmp)
+
+        return conversations
+
+    def getLine(self, sentence):
+        line = {}
+        line["text"] = self.tag_re.sub('', sentence).replace('\\\'','\'').strip().lower()
+        return line
+
+    def filter(self, lines):
+        # Use the followint to customize filtering of QA pairs
+        #
+        # startwords = ("what", "how", "when", "why", "where", "do", "did", "is", "are", "can", "could", "would", "will")
+        # question = lines["lines"][0]["text"]
+        # if not question.endswith('?'):
+        #     return False
+        # if not question.split(' ')[0] in startwords:
+        #     return False
+        #
+        return True
+
+    def getXML(self, filepath):
+        fext = os.path.splitext(filepath)[1]
+        if fext == '.gz':
+            tmp = GzipFile(filename=filepath)
+            return ET.parse(tmp)
+        else:
+            return ET.parse(filepath)
+
+    def filesInDir(self, dirname):
+        result = []
+        for dirpath, dirs, files in os.walk(dirname):
+            for filename in files:
+                fname = os.path.join(dirpath, filename)
+                result.append(fname)
+        return result

--- a/chatbot/textdata.py
+++ b/chatbot/textdata.py
@@ -26,7 +26,7 @@ import os  # Checking file existance
 import random
 
 from chatbot.cornelldata import CornellData
-
+from chatbot.opensubsdata import OpensubsData
 
 class Batch:
     """Struct containing batches info
@@ -52,7 +52,7 @@ class TextData:
         self.args = args
 
         # Path variables
-        self.corpusDir = os.path.join(self.args.rootDir, 'data/cornell/')
+        self.corpusDir = os.path.join(self.args.rootDir, 'data', self.args.corpus)
         self.samplesDir = os.path.join(self.args.rootDir, 'data/samples/')
         self.samplesName = self._constructName()
 
@@ -211,8 +211,12 @@ class TextData:
         if not datasetExist:  # First time we load the database: creating all files
             print('Training samples not found. Creating dataset...')
             # Corpus creation
-            cornellData = CornellData(self.corpusDir)
-            self.createCorpus(cornellData.getConversations())
+            if self.args.corpus == 'cornell':
+                cornellData = CornellData(self.corpusDir)
+                self.createCorpus(cornellData.getConversations())
+            elif self.args.corpus == 'opensubs':
+                opensubsData = OpensubsData(self.corpusDir)
+                self.createCorpus(opensubsData.getConversations())
 
             # Saving
             print('Saving dataset...')

--- a/data/opensubs/.gitignore
+++ b/data/opensubs/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except these files
+!.gitignore
+!README

--- a/data/opensubs/README
+++ b/data/opensubs/README
@@ -1,0 +1,7 @@
+In order to use the Opensubtitles dataset, you must first download and unpack the archive in this foler.
+
+Download english corpus directly here:
+http://opus.lingfil.uu.se/download.php?f=OpenSubtitles/en.tar.gz
+
+All details on the corpus here:
+http://opus.lingfil.uu.se/OpenSubtitles.php


### PR DESCRIPTION
I've integrated the logic to load the opensubtitles corpus:
python main.py --createDataset --corpus opensubs

This loads  981660 QA with a vocabulary size of 96895 words. The opensubsdata.py provides methods to perform additional filtering on the dataset, for example only including questions/answers pairs.