### PR TITLE
tf: Scope model under a model identifier (WIP)

### DIFF
--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -148,6 +148,12 @@ class Chatbot:
 
         #tf.logging.set_verbosity(tf.logging.INFO) # DEBUG, INFO, WARN (default), ERROR, or FATAL
 
+        # Scope everything under a model identifier, to be able to instantiate 
+        # multiple `Chatbot` instances from the same Python execution environment.
+        with tf.variable_scope(self.args.modelTag or ""):
+            self.mainScoped()
+
+    def mainScoped(self):
         self.loadModelParams()  # Update the self.modelDir and self.globStep, for now, not used when loading Model (but need to be called before _getSummaryName)
 
         self.textData = TextData(self.args)


### PR DESCRIPTION
So what I want to be able to do is:

```py
botFoo = chatbot.Chatbot()
botFoo.main(['--modelTag', "foo", '--test', 'daemon'])

botBar = chatbot.Chatbot()
botBar.main(['--modelTag', "bar", '--test', 'daemon'])
```

This does not work right now as there are collisions between variable names in the TF symbolic graph. This first commit is – I think – a right step towards fixing this, but is not enough: I think in the `model.py` file, where we rely on the `tf.nn.seq2seq.embedding_rnn_seq2seq` implementation, something must not be properly scoped.

What do you guys think?