### PR TITLE
Added support for fasttext word embeddings

### DIFF
--- a/chatbot/textdata.py
+++ b/chatbot/textdata.py
@@ -249,7 +249,6 @@ class TextData:
             print('Saving dataset...')
             self.saveDataset(dirName)  # Saving tf samples
         else:
-            print('Loading dataset from {}...'.format(dirName))
             self.loadDataset(dirName)
 
         assert self.padToken == 0
@@ -273,7 +272,9 @@ class TextData:
         Args:
             dirName (str): The directory where to load the model
         """
-        with open(os.path.join(dirName, self.samplesName), 'rb') as handle:
+        dataset_path = os.path.join(dirName, self.samplesName)
+        print('Loading dataset from {}'.format(dataset_path))
+        with open(dataset_path, 'rb') as handle:
             data = pickle.load(handle)  # Warning: If adding something here, also modifying saveDataset
             self.word2id = data['word2id']
             self.id2word = data['id2word']

--- a/data/embeddings/.gitignore
+++ b/data/embeddings/.gitignore
@@ -1,5 +1,6 @@
 # Ignore everything in this directory
 *
 # Except these files
-!README
+!README*
 !.gitignore
+!*.py

--- a/data/embeddings/README.md
+++ b/data/embeddings/README.md
@@ -1,0 +1,13 @@
+In order to use a pre-trained word2vec file, you must first download it and place it here. DeepQA supports both the .bin format of the Google News word2vec embeddings, and the .vec format of the Facebook fasttext embeddings. The vec2bin.py is a small utility script to convert a .vec to a .bin file, which reduces disk space and improve the loading time.
+
+Usage:
+python main.py --initEmbeddings --embeddingSource=wiki.en.bin
+
+Google News embeddings:
+https://drive.google.com/file/d/0B7XkCwpI5KDYNlNUTTlSS21pQmM/edit?usp=sharing
+
+FastText embeddings:
+https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md
+
+More details on word2vec and these pre-trained vectors:
+https://code.google.com/archive/p/word2vec/

--- a/data/embeddings/vec2bin.py
+++ b/data/embeddings/vec2bin.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+import sys
+import getopt
+import numpy as np
+
+from tqdm import tqdm
+
+input_path = 'wiki.fr.vec'
+output_path = 'wifi.fr.bin'
+
+def vec2bin(input_path, output_path):
+    input_fd  = open(input_path, "rb")
+    output_fd = open(output_path, "wb")
+
+    header = input_fd.readline()
+    output_fd.write(header)
+
+    vocab_size, vector_size = map(int, header.split())
+
+    for line in tqdm(range(vocab_size)):
+        word = []
+        while True:
+            ch = input_fd.read(1)
+            output_fd.write(ch)
+            if ch == b' ':
+                word = b''.join(word).decode('utf-8')
+                break
+            if ch != b'\n':
+                word.append(ch)
+        vector = np.fromstring(input_fd.readline(), sep=' ', dtype='float32')
+        output_fd.write(vector.tostring())
+
+    input_fd.close()
+    output_fd.close()
+
+
+def main(argv):
+   inputfile = False
+   outputfile = False
+   try:
+      opts, args = getopt.getopt(argv,"hi:o:",["ifile=","ofile="])
+   except getopt.GetoptError:
+      print('vec2bin.py -i <inputfile> -o <outputfile>')
+      sys.exit(2)
+   for opt, arg in opts:
+      if opt == '-h':
+         print('test.py -i <inputfile> -o <outputfile>')
+         sys.exit()
+      elif opt in ("-i", "--ifile"):
+         inputfile = arg
+      elif opt in ("-o", "--ofile"):
+         outputfile = arg
+
+   if not inputfile or not outputfile:
+       print('vec2bin.py -i <inputfile> -o <outputfile>')
+       sys.exit(2)
+
+   print('Converting %s to binary file format' % inputfile)
+   vec2bin(inputfile, outputfile)
+
+if __name__ == "__main__":
+   main(sys.argv[1:])

--- a/data/word2vec/README.md
+++ b/data/word2vec/README.md
@@ -1,5 +1,0 @@
-In order to use a pre-trained word2vec file, you must first download it and place it here.
-https://drive.google.com/file/d/0B7XkCwpI5KDYNlNUTTlSS21pQmM/edit?usp=sharing
-
-More details on word2vec and these pre-trained vectors:
-https://code.google.com/archive/p/word2vec/


### PR DESCRIPTION
Facebook AI research group recently released pre-trained word embeddings over 90 languages:
https://github.com/facebookresearch/fastText/blob/master/pretrained-vectors.md

This pull-request adds support for the FastText embeddings, thus making it easier to train models with small datasets in languages other than EN. Default behavior stays the same as previously (using GoogleNews embedding). A new argument enables to select the embeddings file.

As an example, here is a conversation in French, using the OpenSubtitles corpus (1024 hiddenSize):
https://gist.github.com/eschnou/340e50388ef479d6ed7bf0a2e83bb46e