### PR TITLE
Feature/vocab limit

### DIFF
--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -114,6 +114,9 @@ class Chatbot:
         datasetArgs.add_argument('--ratioDataset', type=float, default=1.0, help='ratio of dataset used to avoid using the whole dataset')  # Not implemented, useless ?
         datasetArgs.add_argument('--maxLength', type=int, default=10, help='maximum length of the sentence (for input and output), define number of maximum step of the RNN')
         datasetArgs.add_argument('--filterVocab', type=int, default=1, help='remove rarelly used words (by default words used only once). 0 to keep all words.')
+        datasetArgs.add_argument('--increaseTrainingPairs', type=bool, default=False, help='Use every line in the dataset as both input and target, thus multiplying by two the training set.')
+        datasetArgs.add_argument('--vocabularySize', type=int, default=40000, help='Limit the number of words in the vocabulary')
+        
 
         # Network options (Warning: if modifying something here, also make the change on save/loadParams() )
         nnArgs = parser.add_argument_group('Network options', 'architecture related option')
@@ -543,6 +546,9 @@ class Chatbot:
             self.args.datasetTag = config['Dataset'].get('datasetTag')
             self.args.maxLength = config['Dataset'].getint('maxLength')  # We need to restore the model length because of the textData associated and the vocabulary size (TODO: Compatibility mode between different maxLength)
             self.args.filterVocab = config['Dataset'].getint('filterVocab')
+            self.increaseTrainingPairs = config['Dataset'].getboolean('increaseTrainingPairs')
+            self.args.vocabularySize = config['Dataset'].getint('vocabularySize')
+            
 
             self.args.hiddenSize = config['Network'].getint('hiddenSize')
             self.args.numLayers = config['Network'].getint('numLayers')
@@ -564,6 +570,8 @@ class Chatbot:
             print('datasetTag: {}'.format(self.args.datasetTag))
             print('maxLength: {}'.format(self.args.maxLength))
             print('filterVocab: {}'.format(self.args.filterVocab))
+            print('increaseTrainingPairs: {}'.format(self.args.increaseTrainingPairs))
+            print('vocabularySize: {}'.format(self.args.vocabularySize))
             print('hiddenSize: {}'.format(self.args.hiddenSize))
             print('numLayers: {}'.format(self.args.numLayers))
             print('softmaxSamples: {}'.format(self.args.softmaxSamples))
@@ -596,7 +604,10 @@ class Chatbot:
         config['Dataset']['datasetTag'] = str(self.args.datasetTag)
         config['Dataset']['maxLength'] = str(self.args.maxLength)
         config['Dataset']['filterVocab'] = str(self.args.filterVocab)
-
+        config['Dataset']['increaseTrainingPairs'] = str(self.args.increaseTrainingPairs)
+        config['Dataset']['vocabularySize'] = str(self.args.vocabularySize)
+        
+        
         config['Network'] = {}
         config['Network']['hiddenSize'] = str(self.args.hiddenSize)
         config['Network']['numLayers'] = str(self.args.numLayers)

--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -114,7 +114,7 @@ class Chatbot:
         datasetArgs.add_argument('--ratioDataset', type=float, default=1.0, help='ratio of dataset used to avoid using the whole dataset')  # Not implemented, useless ?
         datasetArgs.add_argument('--maxLength', type=int, default=10, help='maximum length of the sentence (for input and output), define number of maximum step of the RNN')
         datasetArgs.add_argument('--filterVocab', type=int, default=1, help='remove rarelly used words (by default words used only once). 0 to keep all words.')
-        datasetArgs.add_argument('--increaseTrainingPairs', type=bool, default=False, help='Use every line in the dataset as both input and target, thus multiplying by two the training set.')
+        datasetArgs.add_argument('--increaseTrainingPairs', action='store_true', help='Use every line in the dataset two times as both input and target, thus multiplying by two the training set.')
         datasetArgs.add_argument('--vocabularySize', type=int, default=40000, help='Limit the number of words in the vocabulary')
         
 

--- a/chatbot/textdata.py
+++ b/chatbot/textdata.py
@@ -369,7 +369,7 @@ class TextData:
         new_mapping = {}  # Map the full words ids to the new one (TODO: Should be a list)
         newId = 0
         
-        print("Filtering dataset with vocabSize={} and wordCount > {}", self.args.vocabularySize,self.args.filterVocab)
+        print("Filtering dataset with vocabSize = ", self.args.vocabularySize, " and wordCount > ", self.args.filterVocab)
         word_counter = collections.Counter(self.idCount)
         selected_word_ids = word_counter.most_common(self.args.vocabularySize)
         selected_word_ids = { k:v for k, v in selected_word_ids if v>self.args.filterVocab }


### PR DESCRIPTION
There are two features in this pull request.
First one is the flag "increaseTrainingPairs", that when it is set it uses consecutive lines in the database as input and target (as always) , and when it is not set is just reads the data in steps of 2 lines, forcing first line as input and second as target. This is necessary if you want the bot to have some personality, like training on a special character from a movie.

The second feature is a limit on the total vocabulary size. Without it, using the Opensubtitles db in Spanish I got around 400k words in the dictionary, way too much. And while I could still play with the vocabFilter parameter, it is better to be able to limit the vocabulary size directly.
I also remove the training samples where the target sentence contains an out-of-vocabulary word. It doesn't really make sense for the bot to output <unknown> words